### PR TITLE
support linux for start/stop scripts

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo "Detecting OS Type"
+
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     echo "Running on Linux"    
     url="https://downloads.ortussolutions.com/ortussolutions/commandbox/6.0.0/commandbox-jre-linux64-6.0.0.zip"
@@ -7,7 +9,8 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
     echo "Running on macOS"
     url="https://downloads.ortussolutions.com/ortussolutions/commandbox/6.0.0/commandbox-jre-darwin64-6.0.0.zip"
 else
-    echo "Unknown operating system '$OSTYPE'"
+    echo "error: unsupported operating system '$OSTYPE'"
+    exit 1
 fi
 
 echo "Downloading zip file..."

--- a/start.sh
+++ b/start.sh
@@ -1,11 +1,19 @@
 #!/bin/bash
 
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    echo "Running on Linux"    
+    url="https://downloads.ortussolutions.com/ortussolutions/commandbox/6.0.0/commandbox-jre-linux64-6.0.0.zip"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "Running on macOS"
+    url="https://downloads.ortussolutions.com/ortussolutions/commandbox/6.0.0/commandbox-jre-darwin64-6.0.0.zip"
+else
+    echo "Unknown operating system '$OSTYPE'"
+fi
+
 echo "Downloading zip file..."
 
 # Setting download path
 downloadPath="./box.zip"
-# Setting URL
-url="https://downloads.ortussolutions.com/ortussolutions/commandbox/6.0.0/commandbox-jre-darwin64-6.0.0.zip"
 
 # Check if the file already exists
 if [ -f "$downloadPath" ]; then


### PR DESCRIPTION
update to the start.sh bash script to support linux by downloading the correct box runtime per `$OSTYPE`